### PR TITLE
Correct spelling in `compile` output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.5]
+
+### Added
+
+* `assertLTE`, `assertGTE`, `assertGT`, and `assertLT`: assertions for comparing a `UInt` with some constant.
+* Miscellaneous issues with the compiler.
+
 ## [v0.9.4]
 
 ### Added

--- a/keelung.cabal
+++ b/keelung.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           keelung
-version:        0.9.3
+version:        0.9.4
 synopsis:       DSL for creating zero-knowledge proofs
 description:    Please see the README on GitHub at <https://github.com/btq-ag/keelung#readme>
 category:       Cryptography

--- a/keelung.cabal
+++ b/keelung.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           keelung
-version:        0.9.4
+version:        0.9.5
 synopsis:       DSL for creating zero-knowledge proofs
 description:    Please see the README on GitHub at <https://github.com/btq-ag/keelung#readme>
 category:       Cryptography

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: keelung
-version: 0.9.4
+version: 0.9.5
 github: "btq-ag/keelung"
 license: Apache-2.0
 author: "BTQ AG"

--- a/src/Keelung.hs
+++ b/src/Keelung.hs
@@ -387,7 +387,7 @@ readKeelungVersion cmd args = do
 
 checkCompilerVersion :: (Int, Int, Int) -> M ()
 checkCompilerVersion (major, minor, patch) = do
-  if major == 0 && minor >= 9 && minor < 10 && patch >= 4
+  if major == 0 && minor >= 9 && minor < 10 && patch >= 5
     then return ()
     else throwError (VersionMismatchError major minor patch)
 
@@ -415,7 +415,7 @@ keelungVersion = let (major, minor, patch) = keelungVersion_ in show major ++ ".
   where
     -- \| The version of Keelung is a triple of three numbers, we're not going full semver yet
     keelungVersion_ :: (Int, Int, Int)
-    keelungVersion_ = (0, 9, 4)
+    keelungVersion_ = (0, 9, 5)
 
 --------------------------------------------------------------------------------
 

--- a/src/Keelung.hs
+++ b/src/Keelung.hs
@@ -284,6 +284,9 @@ elaborateAndEncode prog = encodeElaborated <$> elaborate prog
     encodeSideEffect (AssignmentU width var uint) = return $ Encoding.AssignmentU width var uint
     encodeSideEffect (DivMod width a b q r) = return $ Encoding.DivMod width a b q r
     encodeSideEffect (AssertLTE width a b) = return $ Encoding.AssertLTE width a b
+    encodeSideEffect (AssertLT width a b) = return $ Encoding.AssertLT width a b
+    encodeSideEffect (AssertGTE width a b) = return $ Encoding.AssertGTE width a b
+    encodeSideEffect (AssertGT width a b) = return $ Encoding.AssertGT width a b
 
 --------------------------------------------------------------------------------
 

--- a/src/Keelung/Error.hs
+++ b/src/Keelung/Error.hs
@@ -33,7 +33,7 @@ instance Show Error where
   show CannotReadVersionError = "Cannot read the version of the Keelung compiler"
   show (VersionMismatchError major minor patch) =
     "The version of the Keelung compiler is not supported: \n"
-      ++ "  expected range of version: >= v0.9.4 and < v0.10.0, but got v"
+      ++ "  expected range of version: >= v0.9.5 and < v0.10.0, but got v"
       ++ show major
       ++ "."
       ++ show minor

--- a/src/Keelung/Monad.hs
+++ b/src/Keelung/Monad.hs
@@ -662,6 +662,25 @@ assertLTE value bound = do
   let encoded = runHeapM heap $ AssertLTE width <$> encode' value <*> pure bound
   modify' (\st -> st {compSideEffects = compSideEffects st :|> encoded})
 
+-- | Assert that a 'UInt' is less than a given bound.
+--
+--   /Example/
+--
+--   @
+-- assertLT3 :: Comp ()
+-- assertLT3 = do
+--     x <- inputUInt
+--     assertLT x 3
+--   @
+--
+--   @since 0.9.5.0
+assertLT :: KnownNat w => UInt w -> Integer -> Comp ()
+assertLT value bound = do
+  heap <- gets compHeap
+  let width = widthOf value
+  let encoded = runHeapM heap $ AssertLT width <$> encode' value <*> pure bound
+  modify' (\st -> st {compSideEffects = compSideEffects st :|> encoded})
+
 --------------------------------------------------------------------------------
 
 -- | Data type representing the side effects of a computation.
@@ -671,4 +690,7 @@ data SideEffect
   | AssignmentU Width Var Encoding.UInt
   | DivMod Width Encoding.UInt Encoding.UInt Encoding.UInt Encoding.UInt
   | AssertLTE Width Encoding.UInt Integer
+  | AssertLT Width Encoding.UInt Integer
+  | AssertGTE Width Encoding.UInt Integer
+  | AssertGT Width Encoding.UInt Integer
   deriving (Show, Eq)

--- a/src/Keelung/Monad.hs
+++ b/src/Keelung/Monad.hs
@@ -14,6 +14,9 @@ module Keelung.Monad
     performDivMod,
     assertDivMod,
     assertLTE,
+    assertLT,
+    assertGTE,
+    assertGT,
     SideEffect (..),
 
     -- * Inputs
@@ -643,7 +646,7 @@ assertDivMod dividend divisor quotient remainder = do
 
 --------------------------------------------------------------------------------
 
--- | Assert that a 'UInt' is less than or equal to a given bound.
+-- | Assert that a 'UInt' is lesser than or equal to a given bound.
 --
 --   /Example/
 --
@@ -662,7 +665,7 @@ assertLTE value bound = do
   let encoded = runHeapM heap $ AssertLTE width <$> encode' value <*> pure bound
   modify' (\st -> st {compSideEffects = compSideEffects st :|> encoded})
 
--- | Assert that a 'UInt' is less than a given bound.
+-- | Assert that a 'UInt' is lesser than a given bound.
 --
 --   /Example/
 --
@@ -679,6 +682,44 @@ assertLT value bound = do
   heap <- gets compHeap
   let width = widthOf value
   let encoded = runHeapM heap $ AssertLT width <$> encode' value <*> pure bound
+  modify' (\st -> st {compSideEffects = compSideEffects st :|> encoded})
+
+-- | Assert that a 'UInt' is greater than or equal to a given bound.
+--
+--   /Example/
+--
+--   @
+-- assertGTE3 :: Comp ()
+-- assertGTE3 = do
+--     x <- inputUInt
+--     assertGTE x 3
+--   @
+--
+--   @since 0.9.5.0
+assertGTE :: KnownNat w => UInt w -> Integer -> Comp ()
+assertGTE value bound = do
+  heap <- gets compHeap
+  let width = widthOf value
+  let encoded = runHeapM heap $ AssertGTE width <$> encode' value <*> pure bound
+  modify' (\st -> st {compSideEffects = compSideEffects st :|> encoded})
+
+-- | Assert that a 'UInt' is greater than a given bound.
+--
+--   /Example/
+--
+--   @
+-- assertGT3 :: Comp ()
+-- assertGT3 = do
+--     x <- inputUInt
+--     assertGT x 3
+--   @
+--
+--   @since 0.9.5.0
+assertGT :: KnownNat w => UInt w -> Integer -> Comp ()
+assertGT value bound = do
+  heap <- gets compHeap
+  let width = widthOf value
+  let encoded = runHeapM heap $ AssertGT width <$> encode' value <*> pure bound
   modify' (\st -> st {compSideEffects = compSideEffects st :|> encoded})
 
 --------------------------------------------------------------------------------

--- a/src/Keelung/Syntax/Counters.hs
+++ b/src/Keelung/Syntax/Counters.hs
@@ -340,7 +340,7 @@ prettyConstraints counters cs binReps =
       if ordinaryConstraintSize == 0
         then ""
         else
-          "    Ordinary constriants ("
+          "    Ordinary constraints ("
             <> show ordinaryConstraintSize
             <> "):\n\n"
             <> unlines (map (\x -> "      " <> show x) cs)
@@ -351,7 +351,7 @@ prettyConstraints counters cs binReps =
       if booleanConstraintSize == 0
         then ""
         else
-          "    Boolean constriants ("
+          "    Boolean constraints ("
             <> show booleanConstraintSize
             <> "):\n\n"
             <> unlines (map ("      " <>) (prettyBooleanConstraints counters))
@@ -362,7 +362,7 @@ prettyConstraints counters cs binReps =
       if null binReps
         then ""
         else
-          "    Binary representation constriants ("
+          "    Binary representation constraints ("
             <> show (length binReps)
             <> "):\n\n"
             <> unlines (map (("      " <>) . show) binReps)

--- a/src/Keelung/Syntax/Encode/Syntax.hs
+++ b/src/Keelung/Syntax/Encode/Syntax.hs
@@ -282,6 +282,9 @@ data SideEffect
   | AssignmentU Width Var UInt
   | DivMod Width UInt UInt UInt UInt
   | AssertLTE Width UInt Integer
+  | AssertLT Width UInt Integer
+  | AssertGTE Width UInt Integer
+  | AssertGT Width UInt Integer
   deriving (Generic, NFData)
 
 instance Serialize SideEffect
@@ -292,3 +295,6 @@ instance Show SideEffect where
   show (AssignmentU w var val) = show (VarU w var) <> " := " <> show val
   show (DivMod _ x y q r) = show x <> " = " <> show q <> " * " <> show y <> " + " <> show r
   show (AssertLTE _ x n) = "assert " <> show x <> " ≤ " <> show n
+  show (AssertLT _ x n) = "assert " <> show x <> " < " <> show n
+  show (AssertGTE _ x n) = "assert " <> show x <> " ≥ " <> show n
+  show (AssertGT _ x n) = "assert " <> show x <> " > " <> show n


### PR DESCRIPTION
`constiants` -> `constraints`
![image](https://user-images.githubusercontent.com/20301223/231678819-31246ef8-dd84-4142-bd06-3d731049f067.png)
